### PR TITLE
fix typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ An ECC-encrypted token should look like this:
             "transactionId": "<hex>"
         },
         "signature": "<base64>",
-        "version": "ECC_v1"
+        "version": "EC_v1"
     }
 
 For more info check out the Apple Pay Programming Guide[2].


### PR DESCRIPTION
According to Apple's spec, the value of version is EC_v1.
(https://developer.apple.com/library/content/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html)